### PR TITLE
Add ability to use cowsay's options

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dotenv": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "really-need": "^1.9.0",
+    "supertest": "^1.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ var app = express();
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
-app.listen(process.env.PORT || 3000);
+var server = app.listen(process.env.PORT || 3000);
 
 app.post('/', function (req, res) {
 	if (req.body.token !== process.env.SLACK_TOKEN) {
@@ -24,10 +24,11 @@ app.post('/', function (req, res) {
 	var tongue = req.body.T || req.body.tongue;
 
 	var response = '```' + cowsay.say({ text: req.body.text, e: eyes, T: tongue }) + '```';
-
 	return res.send(response);
 });
 
 app.all('*', function (req, res) {
 	return res.status(400).send("Error: Please check your Slash Command's Integration URL");
 });
+
+module.exports = server;

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,10 @@ app.post('/', function (req, res) {
 		return res.send('');
 	}
 
+	if (!req.body.text){
+		return res.status(400).send("Text should be sent together with token");
+	}
+
 	var eyes = req.body.e || req.body.eyes;
 	var tongue = req.body.T || req.body.tongue;
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,10 @@ app.post('/', function (req, res) {
 		return res.send('');
 	}
 
-	var response = '```' + cowsay.say({ text: req.body.text }) + '```';
+	var eyes = req.body.e || req.body.eyes;
+	var tongue = req.body.T || req.body.tongue;
+
+	var response = '```' + cowsay.say({ text: req.body.text, e: eyes, T: tongue }) + '```';
 
 	return res.send(response);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -29,5 +29,5 @@ app.post('/', function (req, res) {
 });
 
 app.all('*', function (req, res) {
-	return res.send("Error: Please check your Slash Command's Integration URL")
+	return res.status(400).send("Error: Please check your Slash Command's Integration URL");
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,0 @@
-describe('moo', function () {
-	it('should return a response', function() {
-		
-	});
-});

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,0 +1,133 @@
+var request = require('supertest');
+require = require('really-need');
+var env = require('dotenv');
+require('dotenv').load();
+var given = require('mocha-testdata');
+
+
+String.prototype.format = function (placeholders) {
+    var s = this;
+    for (var propertyName in placeholders) {
+        var re = new RegExp('{' + propertyName + '}', 'gm');
+        s = s.replace(re, placeholders[propertyName]);
+    }
+    return s;
+};
+
+var allParamsResponseTemplate = "``` ______________________\n< {text} >\n ----------------------\n        \\   ^__^\n         \\  ({eyes})\\_______\n            (__)\\       )\\/\\\n             {tongue} ||----w |\n                ||     ||```";
+var textOnlyResponseTemplate = "``` ______________________\n< {text} >\n ----------------------\n        \\   ^__^\n         \\  ({eyes})\\_______\n            (__)\\       )\\/\\\n                ||----w |\n                ||     ||```";
+var correctToken = "test123";
+process.env.SLACK_TOKEN = correctToken;
+
+describe('loading server', function () {
+    var server;
+    beforeEach(function () {
+        server = require('../src/index', {bustCache: true});
+    });
+    afterEach(function (done) {
+        server.close(done);
+    });
+
+    it("responds with 400 error message when text is not passed", function testCorrectToken(done) {
+        var text = "";
+        var eyes = "";
+        var tongue = "";
+
+
+        var reqBody = {"token": correctToken, "text": text, "e": eyes, "T":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(400, "Text should be sent together with token",  done);
+    });
+
+    it("responds with 200 code and message when token and text are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "";
+        var tongue = "";
+
+        var reqBody = {"token": correctToken, "text": text, "e": eyes, "T":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, textOnlyResponseTemplate.format({text: text, eyes: "oo", tongue: tongue}), done);
+    });
+
+    it("responds with 200 code and message when token text and eyes are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "";
+
+        var reqBody = {"token": correctToken, "text": text, "e": eyes, "T":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, textOnlyResponseTemplate.format({text: text, eyes: eyes, tongue: tongue}), done);
+    });
+
+    it("responds with 200 code and message when token text, eyes and tongue are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "U";
+
+        var reqBody = {"token": correctToken, "text": text, "e": eyes, "T":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, allParamsResponseTemplate.format({text: text, eyes: eyes, tongue: tongue}), done);
+    });
+
+    it("responds with 200 code and message when token text, (alternative) eyes and tongue are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "U";
+
+        var reqBody = {"token": correctToken, "text": text, "eyes": eyes, "T":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, allParamsResponseTemplate.format({text: text, eyes: eyes, tongue: tongue}), done);
+    });
+
+    it("responds with 200 code and message when token text, eyes and (alternative) tongue are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "U";
+
+        var reqBody = {"token": correctToken, "text": text, "eyes": eyes, "tongue":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, allParamsResponseTemplate.format({text: text, eyes: eyes, tongue: tongue}), done);
+    });
+
+    it("responds with 200 code and message when token text, (alternative) eyes and (alternative) tongue are passed", function testCorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "U";
+
+        var reqBody = {"token": correctToken, "text": text, "eyes": eyes, "tongue":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, allParamsResponseTemplate.format({text: text, eyes: eyes, tongue: tongue}), done);
+    });
+
+    it("should send an empty reposnse when token is incorrect", function testIncorrectToken(done) {
+        var text = "moo is a cool module";
+        var eyes = "**";
+        var tongue = "U";
+
+        var reqBody = {"token": "test", "text": text, "eyes": eyes, "tongue":tongue};
+        request(server)
+            .post("")
+            .send(reqBody)
+            .expect(200, "", done);
+    });
+
+    it('responds incorrect request', function testSlash(done) {
+        request(server)
+            .get('/')
+            .expect(400, "Error: Please check your Slash Command's Integration URL", done);
+    });
+});


### PR DESCRIPTION
You can pass cow's option in a more or less verbose way . Both should work : 
```
{
	"text" : "I'm a moooodule",
        "token": "your_token",
	"e" : "oO",
	"T" : "U "
}
```


```
{
	"text" : "I'm a moooodule",
        "token": "your_token",
	"eyes" : "oO",
	"tongue" : "U "
}
```